### PR TITLE
Change to using sobek instead of goja

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/szkiba/xk6-dotenv
 
-go 1.19
+go 1.20
 
 require (
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
We are moving to a fork of goja under grafana org called sobek.

More info in:
- https://github.com/grafana/k6/issues/3772
- https://github.com/grafana/k6/issues/3773
